### PR TITLE
Add link to template notebook

### DIFF
--- a/notebook-template.md
+++ b/notebook-template.md
@@ -20,5 +20,7 @@ Ask questions throughout your document to **keep the student engaged** and think
 
 Summarize your notebook. **Reiterate** the lesson and important takeaways.   
 
+### Sample Template Notebook
+Refer to [this link](https://github.com/callysto/notebook-templates/blob/master/templates/Notebook_Template_With_TableContents.ipynb) to access a template notebook with magics, table of contents, banners, sample questions, headers and subheaders matching the bare bones template in this section.
 
 ##### Does your notebook contain all these items? If not be sure to add them.


### PR DESCRIPTION
I do not have push permission on either branch. Here is an updated notebook-template.md

# Below is a "Bare Bones" Template of How Your Notebooks Should be Formatted

## Introduction

**Motivate**  and introduce the content and context of your notebook. **Why** are you creating this notebook? **What** will you teach? **Why** should the reader care?

### Background

Include the background information about your content. Include examples and explanation to help guide your notebooks.

#### Examples

Use Python or your own explanations to provide **examples and interactivity** to help teach and showcase the concepts to the student.

#### Questions

Ask questions throughout your document to **keep the student engaged** and thinking about the content you've provided.

## Conclusion

Summarize your notebook. **Reiterate** the lesson and important takeaways.   


### Sample Template Notebook
Refer to [this link](https://github.com/callysto/notebook-templates/blob/master/templates/Notebook_Template_With_TableContents.ipynb) to access a template notebook with magics, table of contents, banners, sample questions, headers and subheaders matching the bare bones template in this section.


##### Does your notebook contain all these items? If not be sure to add them.
